### PR TITLE
Fix quiz form markup on exercises page

### DIFF
--- a/uebungen.html
+++ b/uebungen.html
@@ -23,14 +23,14 @@
 
 <main class="container" role="main">
     <section class="content-section">
-        <form id="simple-quiz">
+        <form id="simple-quiz" class="chapter-quiz" data-answer="b">
             <p>Welche Aufgabe hat ein Betriebssystem?</p>
             <label><input type="radio" name="q1" value="a"> Nur Spiele ausführen</label><br>
             <label><input type="radio" name="q1" value="b"> Ressourcen verwalten und Programme ausführen</label><br>
             <label><input type="radio" name="q1" value="c"> Texte formatieren</label><br>
             <button type="submit">Antwort prüfen</button>
+            <p class="quiz-result"></p>
         </form>
-        <p id="quiz-result"></p>
     </section>
 </main>
 


### PR DESCRIPTION
## Summary
- ensure quiz on `uebungen.html` uses the same markup as the chapter quizzes

## Testing
- `python3 tests/check_lang.py`
- `python3 tests/check_alt.py`
- `python3 tests/check_links.py`


------
https://chatgpt.com/codex/tasks/task_e_685a67c57d6c832f8ed6bb6f4142a882