### PR TITLE
Fix dark mode styling for code blocks

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -227,6 +227,14 @@ code, pre {
     border-radius: 4px;
 }
 
+/* Bessere Lesbarkeit der Codeblöcke im Dark Mode */
+body.dark-mode code,
+body.dark-mode pre {
+    background-color: #2b2b2b;
+    border-color: var(--border-color);
+    color: var(--text-color);
+}
+
 code {
     padding: 2px 5px;
 }


### PR DESCRIPTION
## Summary
- tweak CSS so code blocks are readable in dark mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a6c798f48832fafd3d03d607ce87c