### PR TITLE
Fix quiz progression logic

### DIFF
--- a/js/quiz.js
+++ b/js/quiz.js
@@ -28,6 +28,7 @@ function initQuizForm(form, section) {
         if (choice.value === correct) {
             result.textContent = 'Richtig!';
             disableQuizForm(form);
+            form.classList.add('done');
             form.classList.add('hidden');
             showNextQuiz(section);
         } else {
@@ -41,7 +42,7 @@ function disableQuizForm(form) {
 }
 
 function showNextQuiz(section) {
-    const next = section.querySelector('.chapter-quiz.hidden');
+    const next = section.querySelector('.chapter-quiz.hidden:not(.done)');
     if (next) {
         next.classList.remove('hidden');
     }

--- a/uebungen.html
+++ b/uebungen.html
@@ -22,7 +22,7 @@
 </header>
 
 <main class="container" role="main">
-    <section class="content-section">
+    <section class="content-section quiz-section">
         <form id="simple-quiz" class="chapter-quiz" data-answer="b">
             <p>Welche Aufgabe hat ein Betriebssystem?</p>
             <label><input type="radio" name="q1" value="a"> Nur Spiele ausführen</label><br>


### PR DESCRIPTION
## Summary
- show unanswered quiz forms properly by ignoring completed quizzes
- mark quizzes as done when answered correctly
- enable quizzes on the exercises page

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685a880f8978832fb6a480dce1912708